### PR TITLE
chore: establish Codecov baseline for coverage badge visibility

### DIFF
--- a/backend/codecov-baseline.txt
+++ b/backend/codecov-baseline.txt
@@ -1,0 +1,1 @@
+Baseline commit to support coverage badge visibility in Codecov.


### PR DESCRIPTION
## Purpose
This PR introduces a dummy commit to create a Codecov baseline.
This will allow the coverage badge to properly reflect metrics instead of showing 'unknown'.

---

### [JP] 概要
Codecovのバッジがunknownと表示される問題を解決するため、ベースライン用の空コミットを作成します。

### [KR] 요약
Codecov 배지가 'unknown'으로 표시되는 문제를 해결하기 위해 더미 커밋 기반선 PR을 생성합니다.