### PR TITLE
feat(ADR 0001): establish monorepo structure with backend/frontend separation

### DIFF
--- a/docs/adr/0001-monorepo-structure.md
+++ b/docs/adr/0001-monorepo-structure.md
@@ -6,6 +6,6 @@ The backend component is first targeted for implementation as the core vocal pro
 
 ---
 
-***Japanese Summary*生結究到物*�*
+***Japanese Summary(テリートーイド)**
 
-日本、この、な、对目要なる。。。
+日ADRでは、この、な、对目要なる。。。

--- a/docs/adr/0001-monorepo-structure.md
+++ b/docs/adr/0001-monorepo-structure.md
@@ -5,7 +5,3 @@ As the project evolves towards a vocal-training and cloud application, we have e
 The backend component is first targeted for implementation as the core vocal processing engine. The frontend will be added later as a separate service (pending).
 
 ---
-
-***Japanese Summary(テリートーイド)**
-
-日ADRでは、この、な、对目要なる。。。

--- a/docs/adr/0001-monorepo-structure.md
+++ b/docs/adr/0001-monorepo-structure.md
@@ -1,0 +1,11 @@
+# ADR 0001: Monorepo Structure and Backend/Frontend Separation
+
+As the project evolves towards a vocal-training and cloud application, we have established a monorepo structure to segregate the frontend and backend components.
+
+The backend component is first targeted for implementation as the core vocal processing engine. The frontend will be added later as a separate service (pending).
+
+---
+
+***Japanese Summary*生結究到物*�*
+
+日本、この、な、对目要なる。。。


### PR DESCRIPTION
### Summary
This ADR defines the rationale for adopting a monorepo structure and clearly separating backend and frontend components.

- ✅ Backend is prioritized as the foundation for vocal signal analysis
- 🚧 Frontend implementation will follow in future ADRs
- 📂 `backend/`, `frontend/` and `docs/` directories structured at root

### Why it matters
- Improves modularity and team scaling
- Enables CI/CD at subproject level
- Allows clear ownership and deploy strategies per component

---

***Japanese Summary（日本語要約）***

本ADRでは、バックエンドとフロントエンドを分離したモノレポ構成を採用し、バックエンドを優先的に実装対象とすることを決定しています。

***Korean Summary（한국어 요약）***

이 ADR은 모노레포 구조를 채택하고, 백엔드와 프론트엔드를 분리하며, 백엔드를 우선 구현 대상으로 삼기로 한 아키텍처 결정을 문서화한 것입니다.